### PR TITLE
fix(document-service-exception): created new exception class

### DIFF
--- a/src/modules/classes/document-service-error.ts
+++ b/src/modules/classes/document-service-error.ts
@@ -1,0 +1,15 @@
+export class DocumentServiceExceptionError extends Error {
+    message: string;
+    stack: string;
+    original: any;
+
+    constructor(error: any) {
+        super();
+
+        if (error) {
+            this.message = error.message;
+            this.stack = error.stack;
+            this.original = error.original;
+        }
+    }
+}

--- a/src/modules/exceptions/document-service.exception.ts
+++ b/src/modules/exceptions/document-service.exception.ts
@@ -1,12 +1,13 @@
 import { HttpStatus } from '@nestjs/common';
 import { LoggedException } from './logged.exception';
+import { DocumentServiceExceptionError } from '../classes/document-service-error';
 
 export class DocumentServiceException extends LoggedException {
     constructor(error) {
         super(
             'Internal Server Error - DMS',
             HttpStatus.INTERNAL_SERVER_ERROR,
-            error
+            new DocumentServiceExceptionError(error)
         );
     }
 }


### PR DESCRIPTION
#### Short description of what this resolves:
Solves issue with DMS errors not being caught by the TryCatch decorator

### PR Checklist
- [x] All `TODO`'s are done and removed
- [x] `package.json` has correct information
- [x] All dependencies are of correct type (regular vs peer vs dev)
- [x] Documented any complicated or confusing code
- [x] No linter errors
- [x] Project packages successfully (`npm pack`)
- [x] Installed local packed version in another project and tested
- [x] Updated README


#### Changes proposed in this pull request:
Created the DocumentServiceExceptionError to cast the raw error in the DocumentServiceException class

**JIRA Task Link:**