### PR TITLE
fix(decorators): Use SetMetadata instead of ReflectMetadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,33 +25,27 @@
             }
         },
         "@nestjs/common": {
-            "version": "5.4.1",
-            "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-5.4.1.tgz",
-            "integrity": "sha512-05XsPaqte1Y8IHDSjMpxR3hfTEJfFcpfC/Ko81r+aUAFhxO8d4oYUzZl8Wob4zeJY6+nmLpuF8jtGeb/X73qiQ==",
+            "version": "6.5.3",
+            "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-6.5.3.tgz",
+            "integrity": "sha512-8d39grIMrUYGKM46BFWxB6csQFCu1S2aK7azPivg7gTRVSbvR84cVd6tgRVM0LwFpqQrtn3Q6G6Pa8FSk7Kh1w==",
             "dev": true,
             "requires": {
-                "axios": "0.18.0",
-                "cli-color": "1.2.0",
-                "deprecate": "1.0.0",
-                "multer": "1.3.0",
+                "axios": "0.19.0",
+                "cli-color": "1.4.0",
                 "uuid": "3.3.2"
             }
         },
         "@nestjs/core": {
-            "version": "5.4.1",
-            "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-5.4.1.tgz",
-            "integrity": "sha512-PAlSEsycXPIdVm1GOeghs0co8cUmMX65FPjzBLtRJKKcPS8YM7Xo3WKd2f2oGMACYNXbulLk8rWN0xTO2HTgww==",
+            "version": "6.5.3",
+            "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-6.5.3.tgz",
+            "integrity": "sha512-ZhYfH49sVmUUw02qsaGozCFOOehlEABakYzRShyDDq30/2+ek3KpE0DfvA9tXlzX2KVrac2qDTBxMOPoJ+zY+g==",
             "dev": true,
             "requires": {
-                "@nuxtjs/opencollective": "0.1.0",
-                "body-parser": "1.18.3",
-                "cors": "2.8.4",
-                "express": "4.16.3",
-                "fast-safe-stringify": "1.2.0",
-                "iterare": "0.0.8",
-                "object-hash": "1.3.0",
+                "@nuxtjs/opencollective": "0.2.2",
+                "fast-safe-stringify": "2.0.6",
+                "iterare": "1.2.0",
+                "object-hash": "1.3.1",
                 "optional": "0.1.4",
-                "path-to-regexp": "2.2.1",
                 "uuid": "3.3.2"
             }
         },
@@ -62,25 +56,23 @@
             "dev": true
         },
         "@nestjs/testing": {
-            "version": "5.4.1",
-            "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-5.4.1.tgz",
-            "integrity": "sha512-sQNTkRz6PvhNDCKRZlF1lYkCKgIV+3Zuu+Ui4Kn1xmVwrgSsjPajmigGtgBCPiK0ozCQtCZtOMQ2ROGb1NjKyw==",
+            "version": "6.5.3",
+            "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-6.5.3.tgz",
+            "integrity": "sha512-W8tPhkNVhmX+jaDu4R7WUOtIl0PK3ZDso434rEm/b1+S6ZRgAKwNVHWM/rwIuTi5+erPTEULtTsZgrXFrzC1sA==",
             "dev": true,
             "requires": {
-                "deprecate": "1.0.0",
                 "optional": "0.1.4"
             }
         },
         "@nuxtjs/opencollective": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/@nuxtjs/opencollective/-/opencollective-0.1.0.tgz",
-            "integrity": "sha512-e09TxGpTxMOfVwvVWPKNttKslnCtbvp5ofc0EwlKdA4IA8AUIyeteGraGZGs+JO4zw4y2+YxRlNN2xQ+c6KFjw==",
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/@nuxtjs/opencollective/-/opencollective-0.2.2.tgz",
+            "integrity": "sha512-69gFVDs7mJfNjv9Zs5DFVD+pvBW+k1TaHSOqUWqAyTTfLcKI/EMYQgvEvziRd+zAFtUOoye6MfWh0qvinGISPw==",
             "dev": true,
             "requires": {
                 "chalk": "^2.4.1",
-                "consola": "^1.4.3",
-                "esm": "^3.0.79",
-                "node-fetch": "^2.2.0"
+                "consola": "^2.3.0",
+                "node-fetch": "^2.3.0"
             }
         },
         "@types/bluebird": {
@@ -197,16 +189,6 @@
                 "@types/mime": "*"
             }
         },
-        "accepts": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
-            "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
-            "dev": true,
-            "requires": {
-                "mime-types": "~2.1.18",
-                "negotiator": "0.6.1"
-            }
-        },
         "ansi-regex": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -222,12 +204,6 @@
                 "color-convert": "^1.9.0"
             }
         },
-        "append-field": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/append-field/-/append-field-0.1.0.tgz",
-            "integrity": "sha1-bdxY+gg8e8VF08WZWygwzCNm1Eo=",
-            "dev": true
-        },
         "argparse": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -237,20 +213,31 @@
                 "sprintf-js": "~1.0.2"
             }
         },
-        "array-flatten": {
-            "version": "1.1.1",
-            "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-            "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
-            "dev": true
-        },
-        "axios": {
-            "version": "0.18.0",
-            "resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
-            "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+        "async": {
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+            "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
             "dev": true,
             "requires": {
-                "follow-redirects": "^1.3.0",
-                "is-buffer": "^1.1.5"
+                "lodash": "^4.17.14"
+            }
+        },
+        "axios": {
+            "version": "0.19.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+            "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+            "dev": true,
+            "requires": {
+                "follow-redirects": "1.5.10",
+                "is-buffer": "^2.0.2"
+            },
+            "dependencies": {
+                "is-buffer": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+                    "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
+                    "dev": true
+                }
             }
         },
         "balanced-match": {
@@ -264,35 +251,6 @@
             "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
             "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w=="
         },
-        "body-parser": {
-            "version": "1.18.3",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
-            "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
-            "dev": true,
-            "requires": {
-                "bytes": "3.0.0",
-                "content-type": "~1.0.4",
-                "debug": "2.6.9",
-                "depd": "~1.1.2",
-                "http-errors": "~1.6.3",
-                "iconv-lite": "0.4.23",
-                "on-finished": "~2.3.0",
-                "qs": "6.5.2",
-                "raw-body": "2.3.3",
-                "type-is": "~1.6.16"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "2.6.9",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                }
-            }
-        },
         "brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -303,32 +261,10 @@
                 "concat-map": "0.0.1"
             }
         },
-        "buffer-from": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-            "dev": true
-        },
         "builtin-modules": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
             "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-            "dev": true
-        },
-        "busboy": {
-            "version": "0.2.14",
-            "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.2.14.tgz",
-            "integrity": "sha1-bCpiLvz0fFe7vh4qnDetNseSVFM=",
-            "dev": true,
-            "requires": {
-                "dicer": "0.2.5",
-                "readable-stream": "1.1.x"
-            }
-        },
-        "bytes": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-            "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
             "dev": true
         },
         "chalk": {
@@ -348,18 +284,6 @@
             "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
             "dev": true
         },
-        "ci-info": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-            "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
-            "dev": true
-        },
-        "circular-json": {
-            "version": "0.5.9",
-            "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.5.9.tgz",
-            "integrity": "sha512-4ivwqHpIFJZBuhN3g/pEcdbnGUywkBblloGbkglyloVjjR3uT6tieI89MVOfbP2tHX5sgb01FuLgAOzebNlJNQ==",
-            "dev": true
-        },
         "class-validator": {
             "version": "0.9.1",
             "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.9.1.tgz",
@@ -371,17 +295,17 @@
             }
         },
         "cli-color": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-1.2.0.tgz",
-            "integrity": "sha1-OlrnT9drYmevZm5p4q+70B3vNNE=",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-1.4.0.tgz",
+            "integrity": "sha512-xu6RvQqqrWEo6MPR1eixqGPywhYBHRs653F9jfXB2Hx4jdM/3WxiNE1vppRmxtMIfl16SFYTpYlrnqH/HsK/2w==",
             "dev": true,
             "requires": {
                 "ansi-regex": "^2.1.1",
                 "d": "1",
-                "es5-ext": "^0.10.12",
-                "es6-iterator": "2",
-                "memoizee": "^0.4.3",
-                "timers-ext": "0.1"
+                "es5-ext": "^0.10.46",
+                "es6-iterator": "^2.0.3",
+                "memoizee": "^0.4.14",
+                "timers-ext": "^0.1.5"
             }
         },
         "color-convert": {
@@ -411,81 +335,19 @@
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
             "dev": true
         },
-        "concat-stream": {
-            "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-            "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-            "dev": true,
-            "requires": {
-                "buffer-from": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.2.2",
-                "typedarray": "^0.0.6"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "2.3.6",
-                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
-                    }
-                },
-                "string_decoder": {
-                    "version": "1.1.1",
-                    "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-                    "dev": true,
-                    "requires": {
-                        "safe-buffer": "~5.1.0"
-                    }
-                }
-            }
-        },
         "config": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/config/-/config-3.1.0.tgz",
-            "integrity": "sha512-t6oDeNQbsIWa+D/KF4959TANzjSHLv1BA/hvL8tHEA3OUSWgBXELKaONSI6nr9oanbKs0DXonjOWLcrtZ3yTAA==",
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/config/-/config-3.2.2.tgz",
+            "integrity": "sha512-rOsfIOAcG82AWouK4/vBS/OKz3UPl2T/kP0irExmXJJOoWg2CmdfPLdx56bCoMUMFNh+7soQkQWCUC8DyemiwQ==",
             "dev": true,
             "requires": {
                 "json5": "^1.0.1"
             }
         },
         "consola": {
-            "version": "1.4.5",
-            "resolved": "https://registry.npmjs.org/consola/-/consola-1.4.5.tgz",
-            "integrity": "sha512-movqq3MbyXbSf7cG/x+EbO3VjKQVZPB/zeB5+lN1TuBYh9BWDemLQca9P+a4xpO4lXva9rz+Bd8XyqlH136Lww==",
-            "dev": true,
-            "requires": {
-                "chalk": "^2.3.2",
-                "figures": "^2.0.0",
-                "lodash": "^4.17.5",
-                "std-env": "^1.1.0"
-            }
-        },
-        "content-disposition": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-            "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
-            "dev": true
-        },
-        "content-type": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-            "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/consola/-/consola-2.9.0.tgz",
+            "integrity": "sha512-34Iue+LRcWbndFIfZc5boNizWlsrRjqIBJZTe591vImgbnq7nx2EzlrLtANj9TH2Fxm7puFJBJAOk5BhvZOddQ==",
             "dev": true
         },
         "cookie": {
@@ -494,36 +356,6 @@
             "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
             "dev": true
         },
-        "cookie-signature": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-            "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
-            "dev": true
-        },
-        "core-util-is": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-            "dev": true
-        },
-        "cors": {
-            "version": "2.8.4",
-            "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.4.tgz",
-            "integrity": "sha1-K9OB8usgECAQXNUOpZ2mMJBpRoY=",
-            "dev": true,
-            "requires": {
-                "object-assign": "^4",
-                "vary": "^1"
-            },
-            "dependencies": {
-                "object-assign": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                    "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-                    "dev": true
-                }
-            }
-        },
         "crypt": {
             "version": "0.0.2",
             "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
@@ -531,18 +363,19 @@
             "dev": true
         },
         "d": {
-            "version": "1.0.0",
-            "resolved": "http://registry.npmjs.org/d/-/d-1.0.0.tgz",
-            "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+            "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
             "dev": true,
             "requires": {
-                "es5-ext": "^0.10.9"
+                "es5-ext": "^0.10.50",
+                "type": "^1.0.1"
             }
         },
         "date-format": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/date-format/-/date-format-1.2.0.tgz",
-            "integrity": "sha1-YV6CjiM90aubua4JUODOzPpuytg=",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/date-format/-/date-format-2.1.0.tgz",
+            "integrity": "sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA==",
             "dev": true
         },
         "debug": {
@@ -552,34 +385,6 @@
             "dev": true,
             "requires": {
                 "ms": "2.0.0"
-            }
-        },
-        "depd": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-            "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-            "dev": true
-        },
-        "deprecate": {
-            "version": "1.0.0",
-            "resolved": "http://registry.npmjs.org/deprecate/-/deprecate-1.0.0.tgz",
-            "integrity": "sha1-ZhSQ7SQokWpsiIPYg05WRvTkpKg=",
-            "dev": true
-        },
-        "destroy": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-            "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-            "dev": true
-        },
-        "dicer": {
-            "version": "0.2.5",
-            "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
-            "integrity": "sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=",
-            "dev": true,
-            "requires": {
-                "readable-stream": "1.1.x",
-                "streamsearch": "0.1.2"
             }
         },
         "diff": {
@@ -594,27 +399,15 @@
             "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=",
             "dev": true
         },
-        "ee-first": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-            "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-            "dev": true
-        },
-        "encodeurl": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-            "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
-            "dev": true
-        },
         "es5-ext": {
-            "version": "0.10.46",
-            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.46.tgz",
-            "integrity": "sha512-24XxRvJXNFwEMpJb3nOkiRJKRoupmjYmOPVlI65Qy2SrtxwOTB+g6ODjBKOtwEHbYrhWRty9xxOWLNdClT2djw==",
+            "version": "0.10.50",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.50.tgz",
+            "integrity": "sha512-KMzZTPBkeQV/JcSQhI5/z6d9VWJ3EnQ194USTUwIYZ2ZbpN8+SGXQKt1h68EX44+qt+Fzr8DO17vnxrw7c3agw==",
             "dev": true,
             "requires": {
                 "es6-iterator": "~2.0.3",
                 "es6-symbol": "~3.1.1",
-                "next-tick": "1"
+                "next-tick": "^1.0.0"
             }
         },
         "es6-iterator": {
@@ -639,33 +432,21 @@
             }
         },
         "es6-weak-map": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
-            "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+            "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
             "dev": true,
             "requires": {
                 "d": "1",
-                "es5-ext": "^0.10.14",
-                "es6-iterator": "^2.0.1",
+                "es5-ext": "^0.10.46",
+                "es6-iterator": "^2.0.3",
                 "es6-symbol": "^3.1.1"
             }
-        },
-        "escape-html": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-            "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-            "dev": true
         },
         "escape-string-regexp": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-            "dev": true
-        },
-        "esm": {
-            "version": "3.0.84",
-            "resolved": "https://registry.npmjs.org/esm/-/esm-3.0.84.tgz",
-            "integrity": "sha512-SzSGoZc17S7P+12R9cg21Bdb7eybX25RnIeRZ80xZs+VZ3kdQKzqTp2k4hZJjR7p9l0186TTXSgrxzlMDBktlw==",
             "dev": true
         },
         "esprima": {
@@ -680,12 +461,6 @@
             "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
             "dev": true
         },
-        "etag": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-            "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-            "dev": true
-        },
         "event-emitter": {
             "version": "0.3.5",
             "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
@@ -696,187 +471,17 @@
                 "es5-ext": "~0.10.14"
             }
         },
-        "express": {
-            "version": "4.16.3",
-            "resolved": "http://registry.npmjs.org/express/-/express-4.16.3.tgz",
-            "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
-            "dev": true,
-            "requires": {
-                "accepts": "~1.3.5",
-                "array-flatten": "1.1.1",
-                "body-parser": "1.18.2",
-                "content-disposition": "0.5.2",
-                "content-type": "~1.0.4",
-                "cookie": "0.3.1",
-                "cookie-signature": "1.0.6",
-                "debug": "2.6.9",
-                "depd": "~1.1.2",
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
-                "finalhandler": "1.1.1",
-                "fresh": "0.5.2",
-                "merge-descriptors": "1.0.1",
-                "methods": "~1.1.2",
-                "on-finished": "~2.3.0",
-                "parseurl": "~1.3.2",
-                "path-to-regexp": "0.1.7",
-                "proxy-addr": "~2.0.3",
-                "qs": "6.5.1",
-                "range-parser": "~1.2.0",
-                "safe-buffer": "5.1.1",
-                "send": "0.16.2",
-                "serve-static": "1.13.2",
-                "setprototypeof": "1.1.0",
-                "statuses": "~1.4.0",
-                "type-is": "~1.6.16",
-                "utils-merge": "1.0.1",
-                "vary": "~1.1.2"
-            },
-            "dependencies": {
-                "body-parser": {
-                    "version": "1.18.2",
-                    "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
-                    "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
-                    "dev": true,
-                    "requires": {
-                        "bytes": "3.0.0",
-                        "content-type": "~1.0.4",
-                        "debug": "2.6.9",
-                        "depd": "~1.1.1",
-                        "http-errors": "~1.6.2",
-                        "iconv-lite": "0.4.19",
-                        "on-finished": "~2.3.0",
-                        "qs": "6.5.1",
-                        "raw-body": "2.3.2",
-                        "type-is": "~1.6.15"
-                    }
-                },
-                "debug": {
-                    "version": "2.6.9",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                },
-                "iconv-lite": {
-                    "version": "0.4.19",
-                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-                    "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-                    "dev": true
-                },
-                "path-to-regexp": {
-                    "version": "0.1.7",
-                    "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-                    "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
-                    "dev": true
-                },
-                "qs": {
-                    "version": "6.5.1",
-                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-                    "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
-                    "dev": true
-                },
-                "raw-body": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
-                    "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
-                    "dev": true,
-                    "requires": {
-                        "bytes": "3.0.0",
-                        "http-errors": "1.6.2",
-                        "iconv-lite": "0.4.19",
-                        "unpipe": "1.0.0"
-                    },
-                    "dependencies": {
-                        "depd": {
-                            "version": "1.1.1",
-                            "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-                            "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
-                            "dev": true
-                        },
-                        "http-errors": {
-                            "version": "1.6.2",
-                            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
-                            "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
-                            "dev": true,
-                            "requires": {
-                                "depd": "1.1.1",
-                                "inherits": "2.0.3",
-                                "setprototypeof": "1.0.3",
-                                "statuses": ">= 1.3.1 < 2"
-                            }
-                        },
-                        "setprototypeof": {
-                            "version": "1.0.3",
-                            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-                            "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
-                            "dev": true
-                        }
-                    }
-                },
-                "safe-buffer": {
-                    "version": "5.1.1",
-                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-                    "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-                    "dev": true
-                },
-                "statuses": {
-                    "version": "1.4.0",
-                    "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-                    "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-                    "dev": true
-                }
-            }
-        },
         "fast-safe-stringify": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-1.2.0.tgz",
-            "integrity": "sha1-69QmZv0Y/k8rpPDSlQZfP4XK3pY=",
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz",
+            "integrity": "sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg==",
             "dev": true
         },
-        "figures": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-            "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-            "dev": true,
-            "requires": {
-                "escape-string-regexp": "^1.0.5"
-            }
-        },
-        "finalhandler": {
-            "version": "1.1.1",
-            "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
-            "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
-            "dev": true,
-            "requires": {
-                "debug": "2.6.9",
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "on-finished": "~2.3.0",
-                "parseurl": "~1.3.2",
-                "statuses": "~1.4.0",
-                "unpipe": "~1.0.0"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "2.6.9",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                },
-                "statuses": {
-                    "version": "1.4.0",
-                    "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-                    "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-                    "dev": true
-                }
-            }
+        "flatted": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
+            "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
+            "dev": true
         },
         "follow-redirects": {
             "version": "1.5.10",
@@ -887,17 +492,16 @@
                 "debug": "=3.1.0"
             }
         },
-        "forwarded": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-            "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
-            "dev": true
-        },
-        "fresh": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-            "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-            "dev": true
+        "fs-extra": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+            "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+            }
         },
         "fs.realpath": {
             "version": "1.0.0",
@@ -925,32 +529,17 @@
             "integrity": "sha512-SUE8hWi8sJSK00NSuD+lJWVUNJtmoHRjXlAcN6dR3kTc4HYY7rey6/LfOC6COW8Wup07Fup1p0Tao57liq9HRA==",
             "dev": true
         },
+        "graceful-fs": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
+            "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
+            "dev": true
+        },
         "has-flag": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
             "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
             "dev": true
-        },
-        "http-errors": {
-            "version": "1.6.3",
-            "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-            "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-            "dev": true,
-            "requires": {
-                "depd": "~1.1.2",
-                "inherits": "2.0.3",
-                "setprototypeof": "1.1.0",
-                "statuses": ">= 1.4.0 < 2"
-            }
-        },
-        "iconv-lite": {
-            "version": "0.4.23",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-            "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-            "dev": true,
-            "requires": {
-                "safer-buffer": ">= 2.1.2 < 3"
-            }
         },
         "inflight": {
             "version": "1.0.6",
@@ -968,26 +557,11 @@
             "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
             "dev": true
         },
-        "ipaddr.js": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
-            "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4=",
-            "dev": true
-        },
         "is-buffer": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
             "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
             "dev": true
-        },
-        "is-ci": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
-            "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
-            "dev": true,
-            "requires": {
-                "ci-info": "^1.5.0"
-            }
         },
         "is-promise": {
             "version": "2.1.0",
@@ -995,16 +569,10 @@
             "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
             "dev": true
         },
-        "isarray": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-            "dev": true
-        },
         "iterare": {
-            "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/iterare/-/iterare-0.0.8.tgz",
-            "integrity": "sha1-qWmoCh+/9rePKHdllNe8K9+raq0=",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/iterare/-/iterare-1.2.0.tgz",
+            "integrity": "sha512-RxMV9p/UzdK0Iplnd8mVgRvNdXlsTOiuDrqMRnDi3wIhbT+JP4xDquAX9ay13R3CH72NBzQ91KWe0+C168QAyQ==",
             "dev": true
         },
         "js-tokens": {
@@ -1040,23 +608,49 @@
                 }
             }
         },
+        "jsonfile": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
         "lodash": {
-            "version": "4.17.11",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-            "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+            "version": "4.17.15",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+            "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
             "dev": true
         },
         "log4js": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/log4js/-/log4js-3.0.6.tgz",
-            "integrity": "sha512-ezXZk6oPJCWL483zj64pNkMuY/NcRX5MPiB0zE6tjZM137aeusrOnW1ecxgF9cmwMWkBMhjteQxBPoZBh9FDxQ==",
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/log4js/-/log4js-4.5.1.tgz",
+            "integrity": "sha512-EEEgFcE9bLgaYUKuozyFfytQM2wDHtXn4tAN41pkaxpNjAykv11GVdeI4tHtmPWW4Xrgh9R/2d7XYghDVjbKKw==",
             "dev": true,
             "requires": {
-                "circular-json": "^0.5.5",
-                "date-format": "^1.2.0",
-                "debug": "^3.1.0",
-                "rfdc": "^1.1.2",
-                "streamroller": "0.7.0"
+                "date-format": "^2.0.0",
+                "debug": "^4.1.1",
+                "flatted": "^2.0.0",
+                "rfdc": "^1.1.4",
+                "streamroller": "^1.0.6"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                }
             }
         },
         "lru-queue": {
@@ -1079,12 +673,6 @@
                 "is-buffer": "~1.1.1"
             }
         },
-        "media-typer": {
-            "version": "0.3.0",
-            "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-            "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
-            "dev": true
-        },
         "memoizee": {
             "version": "0.4.14",
             "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.14.tgz",
@@ -1099,39 +687,6 @@
                 "lru-queue": "0.1",
                 "next-tick": "1",
                 "timers-ext": "^0.1.5"
-            }
-        },
-        "merge-descriptors": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-            "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
-            "dev": true
-        },
-        "methods": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-            "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
-            "dev": true
-        },
-        "mime": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-            "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
-            "dev": true
-        },
-        "mime-db": {
-            "version": "1.37.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-            "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
-            "dev": true
-        },
-        "mime-types": {
-            "version": "2.1.21",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
-            "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
-            "dev": true,
-            "requires": {
-                "mime-db": "~1.37.0"
             }
         },
         "minimatch": {
@@ -1164,60 +719,23 @@
             "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
             "dev": true
         },
-        "multer": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/multer/-/multer-1.3.0.tgz",
-            "integrity": "sha1-CSsmcPaEb6SRSWXvyM+Uwg/sbNI=",
-            "dev": true,
-            "requires": {
-                "append-field": "^0.1.0",
-                "busboy": "^0.2.11",
-                "concat-stream": "^1.5.0",
-                "mkdirp": "^0.5.1",
-                "object-assign": "^3.0.0",
-                "on-finished": "^2.3.0",
-                "type-is": "^1.6.4",
-                "xtend": "^4.0.0"
-            }
-        },
-        "negotiator": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-            "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
-            "dev": true
-        },
         "next-tick": {
             "version": "1.0.0",
-            "resolved": "http://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
             "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
             "dev": true
         },
         "node-fetch": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
-            "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==",
-            "dev": true
-        },
-        "object-assign": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-            "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+            "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
             "dev": true
         },
         "object-hash": {
-            "version": "1.3.0",
-            "resolved": "http://registry.npmjs.org/object-hash/-/object-hash-1.3.0.tgz",
-            "integrity": "sha512-05KzQ70lSeGSrZJQXE5wNDiTkBJDlUT/myi6RX9dVIvz7a7Qh4oH93BQdiPMn27nldYvVQCKMUaM83AfizZlsQ==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.1.tgz",
+            "integrity": "sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==",
             "dev": true
-        },
-        "on-finished": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-            "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-            "dev": true,
-            "requires": {
-                "ee-first": "1.1.1"
-            }
         },
         "once": {
             "version": "1.4.0",
@@ -1232,12 +750,6 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/optional/-/optional-0.1.4.tgz",
             "integrity": "sha512-gtvrrCfkE08wKcgXaVwQVgwEQ8vel2dc5DDBn9RLQZ3YtmtkBss6A2HY6BnJH4N/4Ku97Ri/SF8sNWE2225WJw==",
-            "dev": true
-        },
-        "parseurl": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-            "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
             "dev": true
         },
         "passport": {
@@ -1268,44 +780,10 @@
             "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
             "dev": true
         },
-        "path-to-regexp": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.2.1.tgz",
-            "integrity": "sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ==",
-            "dev": true
-        },
         "pause": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
             "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10=",
-            "dev": true
-        },
-        "process-nextick-args": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-            "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-            "dev": true
-        },
-        "proxy-addr": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
-            "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
-            "dev": true,
-            "requires": {
-                "forwarded": "~0.1.2",
-                "ipaddr.js": "1.8.0"
-            }
-        },
-        "qs": {
-            "version": "6.5.2",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-            "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-            "dev": true
-        },
-        "range-parser": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-            "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
             "dev": true
         },
         "raven": {
@@ -1319,30 +797,6 @@
                 "stack-trace": "0.0.10",
                 "timed-out": "4.0.1",
                 "uuid": "3.3.2"
-            }
-        },
-        "raw-body": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
-            "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
-            "dev": true,
-            "requires": {
-                "bytes": "3.0.0",
-                "http-errors": "1.6.3",
-                "iconv-lite": "0.4.23",
-                "unpipe": "1.0.0"
-            }
-        },
-        "readable-stream": {
-            "version": "1.1.14",
-            "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-            "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-            "dev": true,
-            "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
-                "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
             }
         },
         "redis": {
@@ -1384,92 +838,24 @@
             }
         },
         "rfdc": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.1.2.tgz",
-            "integrity": "sha512-92ktAgvZhBzYTIK0Mja9uen5q5J3NRVMoDkJL2VMwq6SXjVCgqvQeVP2XAaUY6HT+XpQYeLSjb3UoitBryKmdA==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.1.4.tgz",
+            "integrity": "sha512-5C9HXdzK8EAqN7JDif30jqsBzavB7wLpaubisuQIGHWf2gUXSpzy6ArX/+Da8RjFpagWsCn+pIgxTMAmKw9Zug==",
             "dev": true
         },
         "rxjs": {
-            "version": "6.3.3",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
-            "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
+            "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
             "dev": true,
             "requires": {
                 "tslib": "^1.9.0"
             }
         },
-        "safe-buffer": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "dev": true
-        },
-        "safer-buffer": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-            "dev": true
-        },
         "semver": {
             "version": "5.7.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
             "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-            "dev": true
-        },
-        "send": {
-            "version": "0.16.2",
-            "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
-            "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
-            "dev": true,
-            "requires": {
-                "debug": "2.6.9",
-                "depd": "~1.1.2",
-                "destroy": "~1.0.4",
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
-                "fresh": "0.5.2",
-                "http-errors": "~1.6.2",
-                "mime": "1.4.1",
-                "ms": "2.0.0",
-                "on-finished": "~2.3.0",
-                "range-parser": "~1.2.0",
-                "statuses": "~1.4.0"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "2.6.9",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                },
-                "statuses": {
-                    "version": "1.4.0",
-                    "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-                    "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-                    "dev": true
-                }
-            }
-        },
-        "serve-static": {
-            "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
-            "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
-            "dev": true,
-            "requires": {
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "parseurl": "~1.3.2",
-                "send": "0.16.2"
-            }
-        },
-        "setprototypeof": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-            "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
             "dev": true
         },
         "sprintf-js": {
@@ -1484,76 +870,35 @@
             "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
             "dev": true
         },
-        "statuses": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-            "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
-            "dev": true
-        },
-        "std-env": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/std-env/-/std-env-1.3.1.tgz",
-            "integrity": "sha512-KI2F2pPJpd3lHjng+QLezu0eq+QDtXcv1um016mhOPAJFHKL+09ykK5PUBWta2pZDC8BVV0VPya08A15bUXSLQ==",
-            "dev": true,
-            "requires": {
-                "is-ci": "^1.1.0"
-            }
-        },
         "streamroller": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-0.7.0.tgz",
-            "integrity": "sha512-WREzfy0r0zUqp3lGO096wRuUp7ho1X6uo/7DJfTlEi0Iv/4gT7YHqXDjKC2ioVGBZtE8QzsQD9nx1nIuoZ57jQ==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-1.0.6.tgz",
+            "integrity": "sha512-3QC47Mhv3/aZNFpDDVO44qQb9gwB9QggMEE0sQmkTAwBVYdBRWISdsywlkfm5II1Q5y/pmrHflti/IgmIzdDBg==",
             "dev": true,
             "requires": {
-                "date-format": "^1.2.0",
-                "debug": "^3.1.0",
-                "mkdirp": "^0.5.1",
-                "readable-stream": "^2.3.0"
+                "async": "^2.6.2",
+                "date-format": "^2.0.0",
+                "debug": "^3.2.6",
+                "fs-extra": "^7.0.1",
+                "lodash": "^4.17.14"
             },
             "dependencies": {
-                "isarray": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                "debug": {
+                    "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
                     "dev": true
-                },
-                "readable-stream": {
-                    "version": "2.3.6",
-                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
-                    }
-                },
-                "string_decoder": {
-                    "version": "1.1.1",
-                    "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-                    "dev": true,
-                    "requires": {
-                        "safe-buffer": "~5.1.0"
-                    }
                 }
             }
-        },
-        "streamsearch": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
-            "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=",
-            "dev": true
-        },
-        "string_decoder": {
-            "version": "0.10.31",
-            "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-            "dev": true
         },
         "supports-color": {
             "version": "5.5.0",
@@ -1616,20 +961,10 @@
                 "tslib": "^1.8.1"
             }
         },
-        "type-is": {
-            "version": "1.6.16",
-            "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
-            "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
-            "dev": true,
-            "requires": {
-                "media-typer": "0.3.0",
-                "mime-types": "~2.1.18"
-            }
-        },
-        "typedarray": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+        "type": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/type/-/type-1.0.1.tgz",
+            "integrity": "sha512-MAM5dBMJCJNKs9E7JXo4CXRAansRfG0nlJxW7Wf6GZzSOvH31zClSaHdIMWLehe/EGMBkqeC55rrkaOr5Oo7Nw==",
             "dev": true
         },
         "typescript": {
@@ -1638,22 +973,10 @@
             "integrity": "sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==",
             "dev": true
         },
-        "unpipe": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-            "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-            "dev": true
-        },
-        "util-deprecate": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-            "dev": true
-        },
-        "utils-merge": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-            "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+        "universalify": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
             "dev": true
         },
         "uuid": {
@@ -1668,22 +991,10 @@
             "integrity": "sha512-Q/wBy3LB1uOyssgNlXSRmaf22NxjvDNZM2MtIQ4jaEOAB61xsh1TQxsq1CgzUMBV1lDrVMogIh8GjG1DYW0zLg==",
             "dev": true
         },
-        "vary": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-            "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
-            "dev": true
-        },
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-            "dev": true
-        },
-        "xtend": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
             "dev": true
         }
     }

--- a/src/modules/decorators/permissions.decorator.ts
+++ b/src/modules/decorators/permissions.decorator.ts
@@ -1,3 +1,3 @@
-import { ReflectMetadata } from '@nestjs/common';
+import { SetMetadata } from '@nestjs/common';
 
-export const Permissions = <T>(...permissions: T[]) => ReflectMetadata('permissions', permissions);
+export const Permissions = <T>(...permissions: T[]) => SetMetadata('permissions', permissions);


### PR DESCRIPTION
#### Short description of what this resolves:
Use `SetMetadata` for Nest 6

### PR Checklist
- [x] All `TODO`'s are done and removed
- [x] `package.json` has correct information
- [x] All dependencies are of correct type (regular vs peer vs dev)
- [x] Documented any complicated or confusing code
- [x] No linter errors
- [x] Project packages successfully (`npm pack`)
- [x] Installed local packed version in another project and tested
- [x] Updated README


#### Changes proposed in this pull request:


**JIRA Task Link:**