### PR TITLE
feat(try-catch): do not wrap exceptions that extend BaseException

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ redis:
 ### Decorators
 There are a few different decorators that we have made available:
 #### @TryCatch(error: Error, options?: { customResponseMessage: string } )
-This decorator will wrap your whole function into a try/catch and you can pass an optional custom error class for it to throw!
+This decorator will wrap your whole function into a try/catch and you can pass an optional custom error class for it to throw!  Errors that are thrown
+that extend this package's BaseException are not re-wrapped.
 
 ```
     @TryCatch(SqlException)

--- a/src/modules/decorators/try-catch.decorator.ts
+++ b/src/modules/decorators/try-catch.decorator.ts
@@ -1,3 +1,4 @@
+import { BaseException } from '../exceptions';
 import { TryCatchException } from '../interfaces/try-catch-exception.interface';
 import { TryCatchOptions } from '../interfaces/try-catch-options.interface';
 
@@ -5,6 +6,9 @@ export function TryCatch(Exception: TryCatchException, options = {} as TryCatchO
 
     // helper function to pass appropriate arguments to exception
     const throwCorrectExceptionStyle = (error) => {
+        if (error instanceof BaseException) {
+            throw error;
+        }
         if (new Exception(error).error) {
             if (options.customResponseMessage) {
                 throw new Exception(error, options.customResponseMessage);
@@ -25,7 +29,7 @@ export function TryCatch(Exception: TryCatchException, options = {} as TryCatchO
 
         // check if original methods is async to determine if decorator should be async
         if (originalMethod.constructor.name === 'AsyncFunction') {
-            descriptor.value = async function(...args) {
+            descriptor.value = async function (...args) {
                 // try catch the original method passing in args it was called with
                 try {
                     return await originalMethod.apply(this, args);
@@ -36,7 +40,7 @@ export function TryCatch(Exception: TryCatchException, options = {} as TryCatchO
             };
         }
         else {
-            descriptor.value = function(...args) {
+            descriptor.value = function (...args) {
                 // try catch the original method passing in args it was called with
                 try {
                     return originalMethod.apply(this, args);


### PR DESCRIPTION
#### Short description of what this resolves:
Do not wrap exceptions thrown in try catch decorated function where the thrown exception extends team hive's BaseException

### PR Checklist
- [x] All `TODO`'s are done and removed
- [x] `package.json` has correct information
- [x] All dependencies are of correct type (regular vs peer vs dev)
- [x] Documented any complicated or confusing code
- [x] No linter errors
- [x] Project packages successfully (`npm pack`)
- [ x Installed local packed version in another project and tested
- [ ] Updated README