### PR TITLE
feat(redis): adds a keyPrefix to redis keys if exists in redis config

### DIFF
--- a/src/modules/services/redis/redis.service.ts
+++ b/src/modules/services/redis/redis.service.ts
@@ -32,7 +32,7 @@ export class RedisService {
 
     getValue(key: string) {
         return new Promise<any>((resolve, reject) => {
-            this.client.connection.get(this.keyPrefix + key, async (error, response) => {
+            this.client.connection.get(`${this.keyPrefix}${key}`, async (error, response) => {
                 if (error) {
                     return reject(error);
                 }
@@ -53,7 +53,7 @@ export class RedisService {
     setValue(key: string, value: any, duration?: number) {
         return new Promise<any>((resolve, reject) => {
             if (duration) {
-                this.client.connection.set(this.keyPrefix + key, JSON.stringify(value), 'EX', duration, (err, response) => {
+                this.client.connection.set(`${this.keyPrefix}${key}`, JSON.stringify(value), 'EX', duration, (err, response) => {
                     if (err) {
                         return reject(err);
                     }
@@ -61,7 +61,7 @@ export class RedisService {
                 });
             }
             else {
-                this.client.connection.set(this.keyPrefix + key, JSON.stringify(value), (err, response) => {
+                this.client.connection.set(`${this.keyPrefix}${key}`, JSON.stringify(value), (err, response) => {
                     if (err) {
                         return reject(err);
                     }
@@ -73,10 +73,10 @@ export class RedisService {
 
     async delete(key: string | string[]) {
         if (Array.isArray(key)) {
-            key.map(individualKey => this.keyPrefix + individualKey);
+            key = key.map(individualKey => this.keyPrefix + individualKey);
         }
         else {
-            key = this.keyPrefix + key;
+            key = `${this.keyPrefix}${key}`;
         }
         try {
             await this.client.connection.del(key);


### PR DESCRIPTION
#### Short description of what this resolves:
Adds a key prefix to redis keys if the redis.keyPrefix option exists in configs

### PR Checklist
- [x] All `TODO`'s are done and removed
- [x] `package.json` has correct information
- [x] All dependencies are of correct type (regular vs peer vs dev)
- [x] Documented any complicated or confusing code
- [x] No linter errors
- [x] Project packages successfully (`npm pack`)
- [x] Installed local packed version in another project and tested
- [x] Updated README

#### Changes proposed in this pull request:
- prefixes keys for getValue, setValue, and deleteValue

**JIRA Task Link:** [LOOP-5883](https://maestro.atlassian.net/browse/LOOP-5883)