### PR TITLE
fix(validation): check array validity in identity array validation

### DIFF
--- a/src/modules/pipes/identity-array-validation.pipe.ts
+++ b/src/modules/pipes/identity-array-validation.pipe.ts
@@ -5,7 +5,13 @@ import { ValidationException } from '../exceptions';
 @Injectable()
 export class IdentityArrayValidationPipe implements PipeTransform<string[]> {
     async transform(values: string[] = []) {
+        if (!values) {
+            throw new ValidationException('array of identities is not defined');
+        }
         const validator = new Validator();
+        if (!validator.isArray(values)) {
+            throw new ValidationException('invalid array');
+        }
         values.forEach((value) => {
             if (!validator.isUUID(value)) {
                 throw new ValidationException('invalid uuid list of identities');


### PR DESCRIPTION
#### Short description of what this resolves:
Array validation caused a 500 if no array is given to validate.

### PR Checklist
- [x] All `TODO`'s are done and removed
- [x] `package.json` has correct information
- [x] All dependencies are of correct type (regular vs peer vs dev)
- [x] Documented any complicated or confusing code
- [x] No linter errors
- [x] Project packages successfully (`npm pack`)
- [x] Installed local packed version in another project and tested
- [x] Updated README


#### Changes proposed in this pull request:
- Validate that the array exists and is valid before validating each member of the array.