### PR TITLE
chore(deps): match rx.js version in angular dev kit

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
         "log4js": "^4.5",
         "passport": "~0.4.0",
         "reflect-metadata": "~0.1.13",
-        "rxjs": "^6.5",
+        "rxjs": "^6.4",
         "tslint": "^5.18",
         "typescript": "^3.5"
     },


### PR DESCRIPTION
#### Short description of what this resolves:
Downgrade rxjs peer dependency to match rxjs version of angular dev kit

### PR Checklist
- [x] All `TODO`'s are done and removed
- [x] `package.json` has correct information
- [x] All dependencies are of correct type (regular vs peer vs dev)
- [x] Documented any complicated or confusing code
- [x] No linter errors
- [x] Project packages successfully (`npm pack`)
- [x] Installed local packed version in another project and tested
- [x] Updated README

