### PR TITLE
feat(validation): export validation errors util

### DIFF
--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -13,3 +13,4 @@ export * from './providers';
 export * from './services';
 export * from './types';
 export * from './validators';
+export * from './utility';

--- a/src/modules/utility/index.ts
+++ b/src/modules/utility/index.ts
@@ -1,0 +1,1 @@
+export * from './throw-validation-errors';

--- a/src/modules/utility/throw-validation-errors.ts
+++ b/src/modules/utility/throw-validation-errors.ts
@@ -1,0 +1,17 @@
+import { ValidationError } from 'class-validator';
+import { ValidationException } from '../exceptions';
+
+export const throwValidationErrors = (errors: ValidationError[]) => {
+    const constraints = errors[0].constraints;
+    const children = errors[0].children;
+    if (constraints) {
+        const message = constraints[Object.keys(constraints)[0]];
+        throw new ValidationException(message);
+    }
+    else if (children) {
+        this.getError(children);
+    }
+    else {
+        throw new ValidationException('Validation Failed');
+    }
+};


### PR DESCRIPTION
#### Short description of what this resolves:
The function used to throw errors based on class validator was not available outside of the nestjs-common.

### PR Checklist
- [x] All `TODO`'s are done and removed
- [x] `package.json` has correct information
- [x] All dependencies are of correct type (regular vs peer vs dev)
- [x] Documented any complicated or confusing code
- [x] No linter errors
- [x] Project packages successfully (`npm pack`)
- [x] Installed local packed version in another project and tested
- [x] Updated README


#### Changes proposed in this pull request:
- Export the validation util