### PR TITLE
feat(pagination): add ability to set secondary sort

### DIFF
--- a/src/modules/dtos/pagination.dto.ts
+++ b/src/modules/dtos/pagination.dto.ts
@@ -35,6 +35,8 @@ export class Pagination {
     sortByModel: any;
     defaultSort: string;
 
+    secondarySort?: any;
+
     static defaultSortDir: SortDirection = 'DESC';
 
     constructor(defaultSortBy: string, options: PaginationOptions) {
@@ -63,6 +65,7 @@ export class Pagination {
     getOrderBy(options = {} as OrderBy) {
         const sortBy = [];
 
+        // primary sort
         if (this.sortByModel) {
             if (Array.isArray(this.sortByModel)) {
                 sortBy.push([...this.sortByModel, this.sortBy, this.sortDir]);
@@ -74,6 +77,12 @@ export class Pagination {
             sortBy.push([this.sortBy, this.sortDir]);
         }
 
+        //secondary sort
+        if (this.secondarySort){
+            sortBy.push(this.secondarySort);
+        }
+
+        // default sort by to ensure consistent pagination regardless of collisions
         if (options.sortById !== false) {
             const sortByKey = options.sortBy || 'id';
             sortBy.push([sortByKey, 'asc']);


### PR DESCRIPTION
#### Short description of what this resolves:
- in pagination dtos, this allows you to set a secondary sort option that will be included in the order clause

### PR Checklist
- [ ] All `TODO`'s are done and removed
- [ ] `package.json` has correct information
- [ ] All dependencies are of correct type (regular vs peer vs dev)
- [ ] Documented any complicated or confusing code
- [ ] No linter errors
- [ ] Project packages successfully (`npm pack`)
- [ ] Installed local packed version in another project and tested
- [ ] Updated README


#### Changes proposed in this pull request:


**JIRA Task Link:**