### PR TITLE
feat(event): support event/message distinction in nest 8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,57 +31,56 @@
             }
         },
         "@nestjs/common": {
-            "version": "7.0.11",
-            "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-7.0.11.tgz",
-            "integrity": "sha512-/Cae4gMfcrBKDnRFRR458MbNgbG/Y3iwZ4nGJ3fdE/1jdhyEdtkzjdcv25awaEY0EdKJ6UkdvYJ8/Gp77X3w9w==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-8.2.0.tgz",
+            "integrity": "sha512-Vska6eEQtnwM9CBnL7QINQUE8Xq+d4s/CXkpxrUab1HgTA9m5LjmkCPdLw7tBFxMQ6Px+kmcXkQI3rKMfq9Wzw==",
             "dev": true,
             "requires": {
-                "axios": "0.19.2",
-                "cli-color": "2.0.0",
-                "iterare": "1.2.0",
-                "tslib": "1.11.2",
-                "uuid": "8.0.0"
+                "axios": "0.24.0",
+                "iterare": "1.2.1",
+                "tslib": "2.3.1",
+                "uuid": "8.3.2"
             },
             "dependencies": {
                 "tslib": {
-                    "version": "1.11.2",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
-                    "integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg==",
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
                     "dev": true
                 },
                 "uuid": {
-                    "version": "8.0.0",
-                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
-                    "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
+                    "version": "8.3.2",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
                     "dev": true
                 }
             }
         },
         "@nestjs/core": {
-            "version": "7.0.11",
-            "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-7.0.11.tgz",
-            "integrity": "sha512-Vob5LokiHO9xAC8c0iKQK6Q8lO29ZCuA3971g+vpX49q92b9BPlhyCbtovZ6Olyy7TBSvetLLDsn+B5/JXgj4g==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-8.2.0.tgz",
+            "integrity": "sha512-TjN705n0DQrcL8hN1021dITol2BgzIT+FFv3RPKJWMwck8y0ebWK0PTI4vXeLial75fPd+4K4LhL6nAO4WyjFw==",
             "dev": true,
             "requires": {
-                "@nuxtjs/opencollective": "0.2.2",
-                "fast-safe-stringify": "2.0.7",
-                "iterare": "1.2.0",
-                "object-hash": "2.0.3",
+                "@nuxtjs/opencollective": "0.3.2",
+                "fast-safe-stringify": "2.1.1",
+                "iterare": "1.2.1",
+                "object-hash": "2.2.0",
                 "path-to-regexp": "3.2.0",
-                "tslib": "1.11.2",
-                "uuid": "8.0.0"
+                "tslib": "2.3.1",
+                "uuid": "8.3.2"
             },
             "dependencies": {
                 "tslib": {
-                    "version": "1.11.2",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
-                    "integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg==",
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
                     "dev": true
                 },
                 "uuid": {
-                    "version": "8.0.0",
-                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
-                    "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
+                    "version": "8.3.2",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
                     "dev": true
                 }
             }
@@ -93,57 +92,108 @@
             "dev": true
         },
         "@nestjs/microservices": {
-            "version": "7.0.11",
-            "resolved": "https://registry.npmjs.org/@nestjs/microservices/-/microservices-7.0.11.tgz",
-            "integrity": "sha512-n1KZc0GBhUM9P3s6UOrUA8T52f+ZDiBh8pnVsv7WcEQlca0EBoq5zkXYtha8ki6gVl4rX4DDuMqFmWzNyo80Uw==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@nestjs/microservices/-/microservices-8.2.0.tgz",
+            "integrity": "sha512-wqrqp//eN4YcfYcyIfv6wtPWWsP/aTxLI4VHYN7n26LSeI1KKiEmZnEdBNl1fW/pnl/HIYnjlUu6hmth338Lrw==",
             "dev": true,
             "requires": {
-                "iterare": "1.2.0",
+                "iterare": "1.2.1",
                 "json-socket": "0.3.0",
-                "tslib": "1.11.2"
+                "tslib": "2.3.1"
             },
             "dependencies": {
                 "tslib": {
-                    "version": "1.11.2",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
-                    "integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg==",
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
                     "dev": true
                 }
             }
         },
         "@nestjs/passport": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@nestjs/passport/-/passport-7.0.0.tgz",
-            "integrity": "sha512-ZJk08zqLxSXY1rXIt9dAK7tcCos3DETQ88Nn/UGmA136SHMG5P0sbw+PU1zfLQyEsU5uHyr7MTD+/S+aOxXS6w==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/@nestjs/passport/-/passport-8.0.1.tgz",
+            "integrity": "sha512-vn/ZJLXQKvSf9D0BvEoNFJLfzl9AVqfGtDyQMfWDLbaNpoEB2FyeaHGxdiX6H71oLSrQV78c/yuhfantzwdjdg==",
             "dev": true
         },
         "@nestjs/testing": {
-            "version": "7.0.11",
-            "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-7.0.11.tgz",
-            "integrity": "sha512-BnGH/apFTN+yHBsT5uSlVWyeYgB5vwLa307ZbnaQL2KkebAEHPXXJp1JlQ3KWzqzXeCjVPTKwAMgpQTuN1k2tg==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-8.2.0.tgz",
+            "integrity": "sha512-8AIZMuPMZ0zIzuR5iOTZ38zH1CjBhhmwQD/thNhIAANWNYKPEpoqNFzol14hiWWsRUpsV9amgljtTf3hzX6KnA==",
             "dev": true,
             "requires": {
                 "optional": "0.1.4",
-                "tslib": "1.11.2"
+                "tslib": "2.3.1"
             },
             "dependencies": {
                 "tslib": {
-                    "version": "1.11.2",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
-                    "integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg==",
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+                    "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
                     "dev": true
                 }
             }
         },
         "@nuxtjs/opencollective": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/@nuxtjs/opencollective/-/opencollective-0.2.2.tgz",
-            "integrity": "sha512-69gFVDs7mJfNjv9Zs5DFVD+pvBW+k1TaHSOqUWqAyTTfLcKI/EMYQgvEvziRd+zAFtUOoye6MfWh0qvinGISPw==",
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/@nuxtjs/opencollective/-/opencollective-0.3.2.tgz",
+            "integrity": "sha512-um0xL3fO7Mf4fDxcqx9KryrB7zgRM5JSlvGN5AGkP6JLM5XEKyjeAiPbNxdXVXQ16isuAhYpvP88NgL2BGd6aA==",
             "dev": true,
             "requires": {
-                "chalk": "^2.4.1",
-                "consola": "^2.3.0",
-                "node-fetch": "^2.3.0"
+                "chalk": "^4.1.0",
+                "consola": "^2.15.0",
+                "node-fetch": "^2.6.1"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+                    "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
             }
         },
         "@opentelemetry/api": {
@@ -447,12 +497,6 @@
                 "debug": "4"
             }
         },
-        "ansi-regex": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-            "dev": true
-        },
         "ansi-styles": {
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -497,12 +541,12 @@
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
         },
         "axios": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-            "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+            "version": "0.24.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+            "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
             "dev": true,
             "requires": {
-                "follow-redirects": "1.5.10"
+                "follow-redirects": "^1.14.4"
             }
         },
         "balanced-match": {
@@ -574,20 +618,6 @@
                 "validator": "13.0.0"
             }
         },
-        "cli-color": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-2.0.0.tgz",
-            "integrity": "sha512-a0VZ8LeraW0jTuCkuAGMNufareGHhyZU9z8OGsW0gXd1hZGi1SRuNRXdbGkraBBKnhyUhyebFWnRbp+dIn0f0A==",
-            "dev": true,
-            "requires": {
-                "ansi-regex": "^2.1.1",
-                "d": "^1.0.1",
-                "es5-ext": "^0.10.51",
-                "es6-iterator": "^2.0.3",
-                "memoizee": "^0.4.14",
-                "timers-ext": "^0.1.7"
-            }
-        },
         "color-convert": {
             "version": "1.9.3",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -638,9 +668,9 @@
             }
         },
         "consola": {
-            "version": "2.12.1",
-            "resolved": "https://registry.npmjs.org/consola/-/consola-2.12.1.tgz",
-            "integrity": "sha512-aEkkju9ZcEa9y2MhzNhfmTUws/CEZZ0LKu0FxftSU3HygPfVMMIMSYyYct+xBN6XNRhsaDZjw2HAv3m2ammXSA==",
+            "version": "2.15.3",
+            "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
+            "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==",
             "dev": true
         },
         "cookie": {
@@ -662,16 +692,6 @@
             "version": "0.0.2",
             "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
             "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
-        },
-        "d": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-            "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-            "dev": true,
-            "requires": {
-                "es5-ext": "^0.10.50",
-                "type": "^1.0.1"
-            }
         },
         "data-uri-to-buffer": {
             "version": "3.0.1",
@@ -734,50 +754,6 @@
             "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
             "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
         },
-        "es5-ext": {
-            "version": "0.10.53",
-            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-            "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-            "dev": true,
-            "requires": {
-                "es6-iterator": "~2.0.3",
-                "es6-symbol": "~3.1.3",
-                "next-tick": "~1.0.0"
-            }
-        },
-        "es6-iterator": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-            "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-            "dev": true,
-            "requires": {
-                "d": "1",
-                "es5-ext": "^0.10.35",
-                "es6-symbol": "^3.1.1"
-            }
-        },
-        "es6-symbol": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-            "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-            "dev": true,
-            "requires": {
-                "d": "^1.0.1",
-                "ext": "^1.1.2"
-            }
-        },
-        "es6-weak-map": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
-            "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
-            "dev": true,
-            "requires": {
-                "d": "1",
-                "es5-ext": "^0.10.46",
-                "es6-iterator": "^2.0.3",
-                "es6-symbol": "^3.1.1"
-            }
-        },
         "escape-string-regexp": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -811,33 +787,6 @@
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
         },
-        "event-emitter": {
-            "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-            "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-            "dev": true,
-            "requires": {
-                "d": "1",
-                "es5-ext": "~0.10.14"
-            }
-        },
-        "ext": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
-            "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
-            "dev": true,
-            "requires": {
-                "type": "^2.0.0"
-            },
-            "dependencies": {
-                "type": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
-                    "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==",
-                    "dev": true
-                }
-            }
-        },
         "extend": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -849,9 +798,9 @@
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
         },
         "fast-safe-stringify": {
-            "version": "2.0.7",
-            "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
-            "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+            "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
             "dev": true
         },
         "file-uri-to-path": {
@@ -866,30 +815,10 @@
             "dev": true
         },
         "follow-redirects": {
-            "version": "1.5.10",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-            "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-            "dev": true,
-            "requires": {
-                "debug": "=3.1.0"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                },
-                "ms": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                    "dev": true
-                }
-            }
+            "version": "1.14.5",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
+            "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==",
+            "dev": true
         },
         "form-data": {
             "version": "2.5.1",
@@ -1090,21 +1019,15 @@
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
             "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
         },
-        "is-promise": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
-            "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
-            "dev": true
-        },
         "isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "iterare": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/iterare/-/iterare-1.2.0.tgz",
-            "integrity": "sha512-RxMV9p/UzdK0Iplnd8mVgRvNdXlsTOiuDrqMRnDi3wIhbT+JP4xDquAX9ay13R3CH72NBzQ91KWe0+C168QAyQ==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/iterare/-/iterare-1.2.1.tgz",
+            "integrity": "sha512-RKYVTCjAnRthyJes037NX/IiqeidgN1xc3j1RjFfECFp28A1GVwK9nA+i0rJPaHqSZwygLzRnFlzUuHFoWWy+Q==",
             "dev": true
         },
         "js-tokens": {
@@ -1192,15 +1115,6 @@
                 "yallist": "^4.0.0"
             }
         },
-        "lru-queue": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
-            "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
-            "dev": true,
-            "requires": {
-                "es5-ext": "~0.10.2"
-            }
-        },
         "lru_map": {
             "version": "0.3.3",
             "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
@@ -1215,22 +1129,6 @@
                 "charenc": "~0.0.1",
                 "crypt": "~0.0.1",
                 "is-buffer": "~1.1.1"
-            }
-        },
-        "memoizee": {
-            "version": "0.4.14",
-            "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.14.tgz",
-            "integrity": "sha512-/SWFvWegAIYAO4NQMpcX+gcra0yEZu4OntmUdrBaWrJncxOqAziGFlHxc7yjKVK2uu3lpPW27P27wkR82wA8mg==",
-            "dev": true,
-            "requires": {
-                "d": "1",
-                "es5-ext": "^0.10.45",
-                "es6-weak-map": "^2.0.2",
-                "event-emitter": "^0.3.5",
-                "is-promise": "^2.1",
-                "lru-queue": "0.1",
-                "next-tick": "1",
-                "timers-ext": "^0.1.5"
             }
         },
         "methods": {
@@ -1290,22 +1188,19 @@
             "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
             "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg=="
         },
-        "next-tick": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-            "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
-            "dev": true
-        },
         "node-fetch": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-            "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
-            "dev": true
+            "version": "2.6.6",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+            "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+            "dev": true,
+            "requires": {
+                "whatwg-url": "^5.0.0"
+            }
         },
         "object-hash": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.0.3.tgz",
-            "integrity": "sha512-JPKn0GMu+Fa3zt3Bmr66JhokJU5BaNBIh4ZeTlaCBzrBsOeXzwcKKAK1tbLiPKgvwmPXsDvvLHoWh5Bm7ofIYg==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+            "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
             "dev": true
         },
         "object-inspect": {
@@ -1721,20 +1616,16 @@
             "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
             "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
         },
-        "timers-ext": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
-            "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
-            "dev": true,
-            "requires": {
-                "es5-ext": "~0.10.46",
-                "next-tick": "1"
-            }
-        },
         "toidentifier": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
             "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+        },
+        "tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+            "dev": true
         },
         "tslib": {
             "version": "1.11.1",
@@ -1772,12 +1663,6 @@
                 "tslib": "^1.8.1"
             }
         },
-        "type": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-            "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
-            "dev": true
-        },
         "type-check": {
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -1787,9 +1672,9 @@
             }
         },
         "typescript": {
-            "version": "3.8.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-            "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+            "version": "4.4.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+            "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
             "dev": true
         },
         "universalify": {
@@ -1832,6 +1717,22 @@
             "resolved": "https://registry.npmjs.org/validator/-/validator-13.0.0.tgz",
             "integrity": "sha512-anYx5fURbgF04lQV18nEQWZ/3wHGnxiKdG4aL8J+jEDsm98n/sU/bey+tYk6tnGJzm7ioh5FoqrAiQ6m03IgaA==",
             "dev": true
+        },
+        "webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+            "dev": true
+        },
+        "whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+            "dev": true,
+            "requires": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+            }
         },
         "word-wrap": {
             "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
         "postpack": "rm *.d.ts && rm *.js && rm -Rf modules"
     },
     "peerDependencies": {
-        "@nestjs/common": "^7.0",
-        "@nestjs/core": "^7.0",
-        "@nestjs/microservices": "^7.0",
-        "@nestjs/passport": "^7.0",
-        "@nestjs/testing": "^7.0",
+        "@nestjs/common": "^8.0",
+        "@nestjs/core": "^8.0",
+        "@nestjs/microservices": "^8.0",
+        "@nestjs/passport": "^8.0",
+        "@nestjs/testing": "^8.0",
         "@teamhive/nestjs-swagger": "^4.6.0",
         "@teamhive/node-common": "^3.4.0",
         "class-validator": "^0.12.2",
@@ -47,11 +47,11 @@
         "rxjs": "^6.5"
     },
     "devDependencies": {
-        "@nestjs/common": "^7.0",
-        "@nestjs/core": "^7.0",
-        "@nestjs/microservices": "^7.0",
-        "@nestjs/passport": "^7.0",
-        "@nestjs/testing": "^7.0",
+        "@nestjs/common": "^8.0",
+        "@nestjs/core": "^8.0",
+        "@nestjs/microservices": "^8.0",
+        "@nestjs/passport": "^8.0",
+        "@nestjs/testing": "^8.0",
         "@teamhive/nestjs-swagger": "^4.6.0",
         "@teamhive/node-common": "3.4.0",
         "@types/bluebird": "^3.5.27",
@@ -68,7 +68,7 @@
         "reflect-metadata": "~0.1.13",
         "rxjs": "^6.5",
         "tslint": "^5.18",
-        "typescript": "^3.7"
+        "typescript": "^4.4"
     },
     "dependencies": {
         "@teamhive/honeycomb-beeline": "^2.8.0-beta.1",

--- a/src/modules/decorators/rpc/get-message-options.ts
+++ b/src/modules/decorators/rpc/get-message-options.ts
@@ -1,0 +1,5 @@
+import { HiveMessageOptions, RPC_OPTIONS_KEY } from './hive-message.decorator';
+
+export function getMessageOptions(target: any): HiveMessageOptions {
+    return Reflect.getMetadata(RPC_OPTIONS_KEY, target) ?? {};
+}

--- a/src/modules/decorators/rpc/hive-message-handler.decorator.ts
+++ b/src/modules/decorators/rpc/hive-message-handler.decorator.ts
@@ -1,9 +1,15 @@
-import { MessagePattern } from '@nestjs/microservices';
+import { EventPattern, MessagePattern } from '@nestjs/microservices';
+import { getMessageOptions } from './get-message-options';
 import { getMessagePattern } from './get-message-pattern';
 
 export function HiveMessageHandler(messageClass: any): MethodDecorator {
     return (target, property, descriptor) => {
         const messagePattern = getMessagePattern(messageClass);
-        MessagePattern(messagePattern)(target, property, descriptor);
+        const messageOptions = getMessageOptions(messageClass);
+        if (messageOptions.isRpc) {
+            MessagePattern(messagePattern)(target, property, descriptor);
+        } else {
+            EventPattern(messagePattern)(target, property, descriptor);
+        }
     };
 }

--- a/src/modules/decorators/rpc/hive-message.decorator.ts
+++ b/src/modules/decorators/rpc/hive-message.decorator.ts
@@ -1,7 +1,13 @@
 export const RPC_PATTERN_KEY = 'loop:rpc-pattern-key';
+export const RPC_OPTIONS_KEY = 'teamhive:rpc-message-options';
 
-export function HiveMessage(messagePattern: string): ClassDecorator {
+export interface HiveMessageOptions {
+    isRpc?: boolean
+}
+
+export function HiveMessage(messagePattern: string, options: HiveMessageOptions = {}): ClassDecorator {
     return (target) => {
         Reflect.defineMetadata(RPC_PATTERN_KEY, messagePattern, target);
+        Reflect.defineMetadata(RPC_OPTIONS_KEY, options, target);
     };
 }


### PR DESCRIPTION
#### Short description of what this resolves:
- in nest 8, event patterns allow for multiple subscriptions in controllers while message patterns are rpc (have a return value) and only support one handler.  This updates the HiveMessage decorator to use the correct controller decorator based on if the handled message is marked for rpc or not
- As this upgrades peer dependencies to nest 8, this should be considered a breaking change

### PR Checklist
- [x] All `TODO`'s are done and removed
- [x] `package.json` has correct information
- [x] All dependencies are of correct type (regular vs peer vs dev)
- [ ] Documented any complicated or confusing code
- [ ] No linter errors
- [ ] Project packages successfully (`npm pack`)
- [ ] Installed local packed version in another project and tested
- [ ] Updated README


#### Changes proposed in this pull request:


**JIRA Task Link:**